### PR TITLE
2 types of Fetchers::default depending on mock feature enabled

### DIFF
--- a/src/datetime_queries/fetch_entries_from_day_to_day.rs
+++ b/src/datetime_queries/fetch_entries_from_day_to_day.rs
@@ -72,7 +72,7 @@ mod tests {
         let wire_vec: Vec<WireElement<Example>> = vec![wire_element.clone()];
         let wire_vec2 = vec![wire_element.clone(), wire_element.clone()];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         // fetch_entries_by_day should be called for each day in the range
         mock_fetchers
             .day

--- a/src/datetime_queries/fetch_entries_from_day_to_hour.rs
+++ b/src/datetime_queries/fetch_entries_from_day_to_hour.rs
@@ -91,7 +91,7 @@ mod tests {
             wire_element.clone(),
         ];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         // fetch_entries_by_day should be called for each day in the range
         mock_fetchers
             .day

--- a/src/datetime_queries/fetch_entries_from_hour_to_day.rs
+++ b/src/datetime_queries/fetch_entries_from_hour_to_day.rs
@@ -90,7 +90,7 @@ mod tests {
             wire_element.clone(),
         ];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         // could set up the expectation each time it is expected to be called to be able to check that the inputs are as expected
         mock_fetchers
             .day

--- a/src/datetime_queries/fetch_entries_from_hour_to_hour.rs
+++ b/src/datetime_queries/fetch_entries_from_hour_to_hour.rs
@@ -116,7 +116,7 @@ mod tests {
             wire_element.clone(),
         ];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .hour
             .expect_fetch_entries_by_hour::<Example>()
@@ -168,7 +168,7 @@ mod tests {
             wire_element.clone(),
         ];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .hour
             .expect_fetch_entries_by_hour::<Example>()
@@ -220,7 +220,7 @@ mod tests {
             wire_element.clone(),
         ];
 
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         // could instead put in the expected FetchEntriesTime struct
         mock_fetchers
             .day

--- a/src/datetime_queries/fetch_in_time_range.rs
+++ b/src/datetime_queries/fetch_in_time_range.rs
@@ -102,7 +102,7 @@ mod tests {
             entry: Example { number: 1 },
         };
         let wire_vec: Vec<WireElement<Example>> = vec![wire_element];
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .day_to_day
             .expect_fetch_entries_from_day_to_day::<Example>()
@@ -139,7 +139,7 @@ mod tests {
             day: 21 as u32,
             hour: Some(10 as u32),
         };
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .day_to_hour
             .expect_fetch_entries_from_day_to_hour::<Example>()
@@ -176,7 +176,7 @@ mod tests {
             day: 21 as u32,
             hour: None,
         };
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .hour_to_day
             .expect_fetch_entries_from_hour_to_day::<Example>()
@@ -213,7 +213,7 @@ mod tests {
             day: 21 as u32,
             hour: Some(10 as u32),
         };
-        let mut mock_fetchers = Fetchers::mock();
+        let mut mock_fetchers = Fetchers::default();
         mock_fetchers
             .hour_to_hour
             .expect_fetch_entries_from_hour_to_hour::<Example>()

--- a/src/datetime_queries/fetchers.rs
+++ b/src/datetime_queries/fetchers.rs
@@ -65,7 +65,7 @@ impl Fetchers {
 }
 #[cfg(feature = "mock")]
 impl Fetchers {
-    pub fn mock() -> Self {
+    pub fn default() -> Self {
         Self {
             day_to_day: FetchByDayDay::new(),
             day_to_hour: FetchByDayHour::new(),


### PR DESCRIPTION
realized that the mock method should be renamed to default, otherwise when using `Fetchers::default()` in a crate with mock feature enabled, the method is not recognized